### PR TITLE
Fixes

### DIFF
--- a/src/Chip8.App/CPU.cs
+++ b/src/Chip8.App/CPU.cs
@@ -198,15 +198,11 @@ public static class Cpu
                         chip8.Memory[chip8.I + 1] = (byte)((chip8.V[tx] % 100) / 10);
                         chip8.Memory[chip8.I + 2] = (byte)(chip8.V[tx] % 10);
                         break;
-                    case 0x55:
-                        for (var i = 0; i <= tx; i++)
-                            chip8.Memory[chip8.I + i] = chip8.V[i];
-
+                    case 0x55: // store registers V0 through Vx in memory starting at location I
+                        chip8.V.AsSpan(0, tx + 1).CopyTo(chip8.Memory.AsSpan(chip8.I, tx + 1));
                         break;
-                    case 0x65:
-                        for (var i = 0; i <= tx; i++)
-                            chip8.V[i] = chip8.Memory[chip8.I + i];
-
+                    case 0x65: // read registers V0 through Vx from memory starting at location I
+                        chip8.Memory.AsSpan(chip8.I, tx + 1).CopyTo(chip8.V.AsSpan(0, tx + 1));
                         break;
                     default:
                         throw new Chip8Exception($"Unsupported opcode {opcode:X4}");

--- a/src/Chip8.App/CPU.cs
+++ b/src/Chip8.App/CPU.cs
@@ -60,65 +60,65 @@ public static class Cpu
         switch (nibble)
         {
             case 0x0000:
-                if (opcode == 0x00e0)
+                if (opcode == 0x00e0) // clear screen
                     Array.Clear(chip8.Gfx);
-                else if (opcode == 0x00ee)
+                else if (opcode == 0x00ee) // return from subroutine
                     chip8.Pc = chip8.Stack[--chip8.Sp];
                 else
                     throw new Chip8Exception($"Unsupported opcode {opcode:X4}");
 
                 break;
-            case 0x1000:
+            case 0x1000: // jump to address NNN
                 chip8.Pc = (ushort)(opcode & 0x0FFF);
                 break;
-            case 0x2000:
+            case 0x2000: // call subroutine at NNN
                 chip8.Stack[chip8.Sp++] = chip8.Pc;
                 chip8.Pc = (ushort)(opcode & 0x0FFF);
                 break;
-            case 0x3000:
+            case 0x3000: // skip next instruction if Vx == NN
                 if (chip8.V[(opcode & 0x0F00) >> 8] == nn)
                     chip8.Pc += 2;
                 break;
-            case 0x4000:
+            case 0x4000: // skip next instruction if Vx != NN
                 if (chip8.V[(opcode & 0x0F00) >> 8] != nn)
                     chip8.Pc += 2;
                 break;
-            case 0x5000:
+            case 0x5000: // skip next instruction if Vx == Vy
                 if (chip8.V[(opcode & 0x0F00) >> 8] == chip8.V[(opcode & 0x00F0) >> 4])
                     chip8.Pc += 2;
                 break;
-            case 0x6000:
+            case 0x6000: // set Vx = NN
                 chip8.V[(opcode & 0x0F00) >> 8] = (byte)nn;
                 break;
-            case 0x7000:
+            case 0x7000: // set Vx = Vx + NN
                 chip8.V[(opcode & 0x0F00) >> 8] += (byte)nn;
                 break;
-            case 0x8000:
+            case 0x8000: // arithmetic operations
                 var vx = (opcode & 0x0F00) >> 8;
                 var vy = (opcode & 0x00F0) >> 4;
                 switch (opcode & 0x000F)
                 {
-                    case 0: chip8.V[vx] = chip8.V[vy]; break;
-                    case 1: chip8.V[vx] = (byte)(chip8.V[vx] | chip8.V[vy]); break;
-                    case 2: chip8.V[vx] = (byte)(chip8.V[vx] & chip8.V[vy]); break;
-                    case 3: chip8.V[vx] = (byte)(chip8.V[vx] ^ chip8.V[vy]); break;
-                    case 4:
+                    case 0: chip8.V[vx] = chip8.V[vy]; break;                       // LD Vx, Vy
+                    case 1: chip8.V[vx] = (byte)(chip8.V[vx] | chip8.V[vy]); break; // OR Vx, Vy
+                    case 2: chip8.V[vx] = (byte)(chip8.V[vx] & chip8.V[vy]); break; // AND Vx, Vy
+                    case 3: chip8.V[vx] = (byte)(chip8.V[vx] ^ chip8.V[vy]); break; // XOR Vx, Vy
+                    case 4:                                                         // ADD Vx, Vy
                         chip8.V[^1] = ToByte(chip8.V[vx] + chip8.V[vy] > 255);
                         chip8.V[vx] = (byte)((chip8.V[vx] + chip8.V[vy]) & 0x00FF);
                         break;
-                    case 5:
+                    case 5: // SUB Vx, Vy
                         chip8.V[^1] = ToByte((chip8.V[vx] > chip8.V[vy]));
                         chip8.V[vx] = (byte)((chip8.V[vx] - chip8.V[vy]) & 0x00FF);
                         break;
-                    case 6:
+                    case 6: // SHR Vx {, Vy}
                         chip8.V[^1] = (byte)(chip8.V[vx] & 0x0001);
                         chip8.V[vx] = (byte)(chip8.V[vx] >> 1);
                         break;
-                    case 7:
+                    case 7: // SUBN Vx, Vy
                         chip8.V[^1] = ToByte(chip8.V[vy] > chip8.V[vx]);
                         chip8.V[vx] = (byte)((chip8.V[vy] - chip8.V[vx]) & 0x00FF);
                         break;
-                    case 14:
+                    case 14: // SHL Vx {, Vy}
                         chip8.V[^1] = ToByte((chip8.V[vx] & 0x80) == 0x80);
                         chip8.V[vx] = (byte)(chip8.V[vx] << 1);
                         break;
@@ -127,22 +127,22 @@ public static class Cpu
                 }
 
                 break;
-            case 0x9000:
+            case 0x9000: // skip next instruction if Vx != Vy
                 if (chip8.V[(opcode & 0x0F00) >> 8] != chip8.V[(opcode & 0x00F0) >> 4])
                     chip8.Pc += 2;
                 break;
-            case 0xA000:
+            case 0xA000: // set I = NNN
                 chip8.I = (ushort)(opcode & 0x0FFF);
                 break;
-            case 0xB000:
+            case 0xB000: // jump to address NNN + V0
                 chip8.Pc = (ushort)((opcode & 0x0FFF) + chip8.V[0]);
                 break;
-            case 0xC000:
+            case 0xC000: // set Vx = random byte AND NN
                 Span<byte> rnd = stackalloc byte[1];
                 Generator.NextBytes(rnd);
                 chip8.V[(opcode & 0x0F00) >> 8] = (byte)(rnd[0] & nn);
                 break;
-            case 0xD000:
+            case 0xD000: // display n-byte sprite starting at memory location I at (Vx, Vy), set VF = collision
             {
                 int x = chip8.V[(opcode & 0x0F00) >> 8];
                 int y = chip8.V[(opcode & 0x00F0) >> 4];
@@ -151,8 +151,9 @@ public static class Cpu
                 break;
             }
 
-            case 0xE000:
+            case 0xE000: // key operations
             {
+                // skip next instruction if key with the value of Vx is pressed
                 if (nn == 0x009E)
                 {
                     if (((chip8.Keyboard >> chip8.V[(opcode & 0x0F00) >> 8]) & 0x01) == 0x01)
@@ -160,6 +161,7 @@ public static class Cpu
                     break;
                 }
 
+                // skip next instruction if key with the value of Vx is not pressed
                 if (nn == 0x00A1)
                 {
                     if (((chip8.Keyboard >> chip8.V[(opcode & 0x0F00) >> 8]) & 0x01) != 0x01)
@@ -167,33 +169,34 @@ public static class Cpu
                     break;
                 }
 
+                // unknown opcode
                 throw new Chip8Exception($"Unsupported opcode {opcode:X4}");
             }
-            case 0xF000:
+            case 0xF000: // miscellaneous operations
                 var tx = (opcode & 0x0F00) >> 8;
 
                 switch (opcode & 0x00FF)
                 {
-                    case 0x7:
+                    case 0x7: // set Vx = delay timer value
                         chip8.V[tx] = chip8.DelayTimer;
                         break;
-                    case 0x0A:
+                    case 0x0A: // wait for a key press, store the value of the key in Vx
                         chip8.WaitingForKeyPress = true;
                         chip8.Pc -= 2;
                         break;
-                    case 0x15:
+                    case 0x15: // set delay timer = Vx
                         chip8.DelayTimer = chip8.V[tx];
                         break;
-                    case 0x18: // sound
+                    case 0x18: // set sound timer = Vx
                         chip8.SoundTimer = chip8.V[tx];
                         break;
-                    case 0x1E:
+                    case 0x1E: // set I = I + Vx
                         chip8.I = (ushort)(chip8.I + chip8.V[tx]);
                         break;
-                    case 0x29:
+                    case 0x29: // set I = location of sprite for digit Vx
                         chip8.I = (ushort)(chip8.V[tx] * 5);
                         break;
-                    case 0x33:
+                    case 0x33: // store BCD representation of Vx in memory locations I, I+1, and I+2
                         chip8.Memory[chip8.I] = (byte)(chip8.V[tx] / 100);
                         chip8.Memory[chip8.I + 1] = (byte)((chip8.V[tx] % 100) / 10);
                         chip8.Memory[chip8.I + 2] = (byte)(chip8.V[tx] % 10);
@@ -204,12 +207,12 @@ public static class Cpu
                     case 0x65: // read registers V0 through Vx from memory starting at location I
                         chip8.Memory.AsSpan(chip8.I, tx + 1).CopyTo(chip8.V.AsSpan(0, tx + 1));
                         break;
-                    default:
+                    default: // unknown opcode
                         throw new Chip8Exception($"Unsupported opcode {opcode:X4}");
                 }
 
                 break;
-            default:
+            default: // unknown opcode
                 throw new Chip8Exception($"Unsupported opcode {opcode:X4}");
         }
     }

--- a/src/Chip8.App/Chip8Exception.cs
+++ b/src/Chip8.App/Chip8Exception.cs
@@ -1,3 +1,3 @@
 ﻿namespace Chip8.App;
 
-public sealed class Chip8Exception(string msg) : Exception;
+public sealed class Chip8Exception(string msg) : Exception(msg);

--- a/src/Chip8.App/Chip8State.cs
+++ b/src/Chip8.App/Chip8State.cs
@@ -170,7 +170,6 @@ public static class State
 
         if (state.AudioDevice == 0)
         {
-            Console.WriteLine("SDL could not open an audio device.");
             state.Error |= StateError.AudioInit;
             return;
         }

--- a/src/Chip8.App/Chip8State.cs
+++ b/src/Chip8.App/Chip8State.cs
@@ -44,6 +44,8 @@ public static class StateErrorExtensions
 
 public sealed class Chip8State
 {
+    static Chip8State() => State = new();
+
     public Sdl Sdl = null!;
     public unsafe Window* Window;
     public unsafe Renderer* Renderer;
@@ -53,9 +55,9 @@ public sealed class Chip8State
     public string RomName = null!;
     public StateError Error;
 
-    public readonly Chip8 Chip8 = new();
+    public Chip8 Chip8 = new();
 
-    public static Chip8State State => new();
+    public static Chip8State State { get; }
 }
 
 public static class State

--- a/src/Chip8.App/Chip8State.cs
+++ b/src/Chip8.App/Chip8State.cs
@@ -6,20 +6,18 @@ namespace Chip8.App;
 
 public sealed class Chip8
 {
-    public readonly byte[] Memory = new byte[4096];
-    public readonly byte[] V = new byte[16];
-    public readonly uint[] Gfx = new uint[64 * 32];
-    public readonly ushort[] Stack = new ushort[16];
-    public byte Sp;
-    public ushort Pc;
-    public ushort I;
-    public byte DelayTimer;
-    public byte SoundTimer; // sound
-    public ushort Keyboard;
-
-    public bool WaitingForKeyPress;
-
-    public readonly Stopwatch Watch = new();
+    public readonly byte[] Memory = new byte[4096];  // 4K memory
+    public readonly byte[] V = new byte[16];         // registers V0 to VF
+    public readonly uint[] Gfx = new uint[64 * 32];  // graphics (64x32 pixels)
+    public readonly ushort[] Stack = new ushort[16]; // call stack
+    public byte Sp;                              // stack pointer
+    public ushort Pc;                            // program counter
+    public ushort I;                             // index
+    public byte DelayTimer;                      // delay
+    public byte SoundTimer;                      // sound
+    public ushort Keyboard;                      // hex keyboard state
+    public bool WaitingForKeyPress;          // true if waiting for a key press to store in Vx
+    public readonly Stopwatch Watch = new();         // timer for 60Hz updates
 }
 
 [Flags]
@@ -55,7 +53,7 @@ public sealed class Chip8State
     public string RomName = null!;
     public StateError Error;
 
-    public Chip8 Chip8 = new();
+    public readonly Chip8 Chip8 = new();
 
     public static Chip8State State { get; }
 }

--- a/src/Chip8.App/Program.cs
+++ b/src/Chip8.App/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Chip8.App;
 using Silk.NET.SDL;
@@ -114,6 +115,7 @@ quit:
     state.Sdl.Dispose();
 }
 
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
 static int KeyCodeToKey(int keycode)
 {
     var keyIndex = keycode < 58


### PR DESCRIPTION
[Copilot]
This pull request improves code clarity and maintainability in the CHIP-8 emulator by adding opcode comments, refactoring memory/register operations, and making minor fixes to class initialization and exception handling. The most significant changes are grouped below:

**Opcode Documentation and Clarity**

* Added descriptive comments for each opcode case in the `Step` method of `CPU.cs`, clarifying the purpose and behavior of each instruction. This makes the code much easier to read and maintain. [[1]](diffhunk://#diff-868935bd50d13c59eb81a1a73e0e935a4c0d36c11493762f9ddaa6ac62d27ed6L63-R121) [[2]](diffhunk://#diff-868935bd50d13c59eb81a1a73e0e935a4c0d36c11493762f9ddaa6ac62d27ed6L130-R145) [[3]](diffhunk://#diff-868935bd50d13c59eb81a1a73e0e935a4c0d36c11493762f9ddaa6ac62d27ed6L154-R215)

**Refactoring and Optimization**

* Replaced manual register-memory copy loops with more efficient `Span.CopyTo` calls for storing/loading registers in the `F000` opcode handler, improving performance and reducing code verbosity.

**Class Initialization and Singleton Pattern**

* Changed the static `Chip8State.State` property to use a static constructor for proper singleton initialization, ensuring only one instance is used throughout the app. [[1]](diffhunk://#diff-e2a8e34f8f6865b3025dcb830d22ad933a0ef7feb0e5f61170030b62b8811203R45-R46) [[2]](diffhunk://#diff-e2a8e34f8f6865b3025dcb830d22ad933a0ef7feb0e5f61170030b62b8811203L58-R58)

**Code Documentation and Readability**

* Added comments to fields in the `Chip8` class to explain their purpose (e.g., memory, registers, graphics, keyboard state), improving code self-documentation.

**Minor Fixes**

* Fixed the `Chip8Exception` constructor to correctly pass the message to the base `Exception` class.
* Removed redundant error message output in audio initialization.
* Added the `AggressiveInlining` attribute to the `KeyCodeToKey` method for potential performance benefits. [[1]](diffhunk://#diff-0de54b59aba41b729df04974e93b392858bd45e6ec79f1886e8607f362eee0efR2) [[2]](diffhunk://#diff-0de54b59aba41b729df04974e93b392858bd45e6ec79f1886e8607f362eee0efR118)